### PR TITLE
Few more doc updates for RTD

### DIFF
--- a/{{ cookiecutter.library_name }}/docs/Makefile
+++ b/{{ cookiecutter.library_name }}/docs/Makefile
@@ -2,8 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
-INTERNALOPTS  = -t internal
+SPHINXOPTS    = -W -t {{ cookiecutter.library_name.replace("_", "-") }}
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
@@ -50,8 +49,6 @@ clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf {{ cookiecutter.library_name }}*.rst
 
-.PHONY: external generate-api
-
 # Generates the API doc
 generate-api:
 	rm -rf temp
@@ -60,12 +57,6 @@ generate-api:
 	SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,ignore-module-all sphinx-apidoc -f -e -o -M . ../{{ cookiecutter.library_name }}
 	-rm dummy.rst
 	mv modules.rst {{ cookiecutter.library_name }}_index.rst
-
-external: generate-api
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	$(INDEXBUILD) -i $(BUILDDIR)/html -o $(BUILDDIR)/html/_static/tipuesearch/tipuesearch_content.js -u $(URLPREFIX)
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: html
 html: generate-api

--- a/{{ cookiecutter.library_name }}/docs/_static/copy_button.css
+++ b/{{ cookiecutter.library_name }}/docs/_static/copy_button.css
@@ -1,0 +1,67 @@
+/* Copy buttons */
+a.copybtn {
+    position: absolute;
+    top: .2em;
+    right: .2em;
+    width: 1em;
+    height: 1em;
+    opacity: .3;
+    transition: opacity 0.5s;
+    border: none;
+    user-select: none;
+}
+
+div.highlight  {
+    position: relative;
+}
+
+a.copybtn > img {
+    vertical-align: top;
+    margin: 0;
+    top: 0;
+    left: 0;
+    position: absolute;
+}
+
+.highlight:hover .copybtn {
+    opacity: 1;
+}
+
+/**
+ * A minimal CSS-only tooltip copied from:
+ *   https://codepen.io/mildrenben/pen/rVBrpK
+ *
+ * To use, write HTML like the following:
+ *
+ * <p class="o-tooltip--left" data-tooltip="Hey">Short</p>
+ */
+ .o-tooltip--left {
+  position: relative;
+ }
+
+ .o-tooltip--left:after {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    content: attr(data-tooltip);
+    padding: 2px;
+    top: 0;
+    left: -.2em;
+    background: grey;
+    font-size: 1rem;
+    color: white;
+    white-space: nowrap;
+    z-index: 2;
+    border-radius: 2px;
+    transform: translateX(-102%) translateY(0);
+    transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+}
+
+.o-tooltip--left:hover:after {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-100%) translateY(0);
+    transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+    transition-delay: .5s;
+}

--- a/{{ cookiecutter.library_name }}/docs/_static/show_block_by_os.js
+++ b/{{ cookiecutter.library_name }}/docs/_static/show_block_by_os.js
@@ -1,0 +1,57 @@
+const supported_oses = ["Windows", "Linux"];
+
+function hideAllBut(os, div=null) {
+    let jq = div === null ? document: div;
+    supported_oses.forEach(function(item, idx) {
+        var selector = ".os-code-block ." + item.toLowerCase()
+        $(jq).find(selector).hide();
+        $(jq).find(".os-code-block li").removeClass("active");
+    });
+
+    $(jq).find(".os-code-block ." + os.toLowerCase()).show();
+    $(jq).find('.os-code-block li:contains("' + os + '")').addClass("active");
+}
+
+function getOS() {
+    var userAgent = window.navigator.userAgent,
+        platform = window.navigator.platform,
+        macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'],
+        windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'],
+        iosPlatforms = ['iPhone', 'iPad', 'iPod'],
+        os = null;
+
+    if (macosPlatforms.indexOf(platform) !== -1) {
+        os = 'Mac OS';
+    } else if (iosPlatforms.indexOf(platform) !== -1) {
+        os = 'iOS';
+    } else if (windowsPlatforms.indexOf(platform) !== -1) {
+        os = 'Windows';
+    } else if (/Android/.test(userAgent)) {
+        os = 'Android';
+    } else if (/Linux/.test(platform)) {
+        os = 'Linux';
+    }
+
+    return os;
+}
+
+
+(function ($) {
+    $(document).ready(function () {
+        var os = getOS();
+
+        if (os == null) {
+             os = 'Windows';
+        }
+
+        $(".os-code-block div.choices li").on("click", function(){
+            var os = $(this).text();
+            $(this).class
+            hideAllBut(os, $(this).closest("div.os-code-block").parent());
+        });
+
+        if (supported_oses.includes(os)) {
+            hideAllBut(os);
+        }
+    });
+})(jQuery);

--- a/{{ cookiecutter.library_name }}/docs/_static/theme_overrides.css
+++ b/{{ cookiecutter.library_name }}/docs/_static/theme_overrides.css
@@ -77,3 +77,40 @@ img.math {
     border-bottom-color: #ced3d3 !important;
     padding-top: 5px !important;
 }
+
+/* define a block that display different instruction per os */
+.os-code-block {
+    border: 1px solid black;
+    padding: 2px;
+}
+
+/* give code block distinct link */
+div.os-code-block div.choices ul {
+    display: inline-block;
+    border: 1px solid black;
+    width: 100%;
+    background-color: #0073a3;
+}
+
+/* Make List elements into links */
+div.os-code-block div.choices li {
+    float: left;
+    list-style: none !important;
+    text-align: center;
+    border-right: 1px solid black;
+    padding: 5px;
+    margin: 0;
+    color: white;
+}
+
+div.os-code-block div.choices li.active {
+    font-weight: bold;
+    background-color: #60add5;
+    text-decoration: underline;
+}
+
+
+/* Make block appear as link */
+div.os-code-block div.choices li:hover {
+    cursor: pointer;
+}

--- a/{{ cookiecutter.library_name }}/docs/_templates/breadcrumbs.html
+++ b/{{ cookiecutter.library_name }}/docs/_templates/breadcrumbs.html
@@ -1,35 +1,9 @@
-{# Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
-
-{% if page_source_suffix %}
-{% set suffix = page_source_suffix %}
-{% else %}
-{% set suffix = source_suffix %}
-{% endif %}
-
-<div aria-label="breadcrumbs navigation" role="navigation">
-    <ul class="wy-breadcrumbs">
-        <li><a href="https://www.idmod.org/documentation">IDM docs</a> &raquo;</li>
-        <li><a href="{{ pathto(master_doc) }}">{{ cookiecutter.library_name.replace("_", "-") }}</a> &raquo;</li>
-        {% for doc in parents %}
+{% extends '!breadcrumbs.html' %}
+{% block breadcrumbs %}
+    <li><a href="https://idmod.org/documentation">IDM docs</a> &raquo;</li>
+    <li><a href="{{ pathto(master_doc) }}">{{ cookiecutter.library_name.replace("_", "-") }}</a> &raquo;</li>
+    {% for doc in parents %}
         <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
-        {% endfor %}
-        <li>{{ title }}</li>
-        <li class="wy-breadcrumbs-aside">
-            {% if pagename != "search" %}
-            {% if display_github %}
-            <a github.comhref="https://{{ github_host|default("") }}/{{ github_user }}/{{ github_repo }}/blob/{{
-            github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> Edit on GitHub</a>
-            {% elif display_bitbucket %}
-            <a class="fa fa-bitbucket"
-               href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}">
-                Edit on Bitbucket</a>
-            {% elif show_source and source_url_prefix %}
-            <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">View page source</a>
-            {% elif show_source and has_source and sourcename %}
-            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
-            {% endif %}
-            {% endif %}
-        </li>
-    </ul>
-    <hr/>
-</div>
+    {% endfor %}
+    <li>{{ title }}</li>
+{% endblock %}

--- a/{{ cookiecutter.library_name }}/docs/conf.py
+++ b/{{ cookiecutter.library_name }}/docs/conf.py
@@ -32,6 +32,8 @@ else:
 
 # -- General configuration ------------------------------------------------
 
+tags.add('{{ cookiecutter.library_name.replace("_", "-") }}')
+
 # If your docs needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
@@ -46,7 +48,9 @@ extensions = [
     'sphinxcontrib.napoleon',
     'sphinx.ext.todo',
     'plantweb.directive',
-    'sphinxcontrib.programoutput'
+    'sphinxcontrib.programoutput',
+    'sphinx.ext.intersphinx',
+    'sphinxext.remoteliteralinclude'
 ]
 
 plantuml = 'plantweb'
@@ -382,3 +386,33 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 # intersphinx_mapping = {'https://docs.python.org/': None}
+
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'emod_api': ('https://docs.idmod.org/projects/emod-api/en/latest/', None),
+                       'emodpy': ('https://docs.idmod.org/projects/emodpy/en/latest/', None),
+                       'idmtools': ('https://docs.idmod.org/projects/idmtools/en/latest/', None),
+                       'idmtools-calibra': ('https://docs.idmod.org/projects/idmtools_calibra/en/latest/', None),
+                       'idmtools-joblib': ('https://docs.idmod.org/projects/idmtools-joblib/en/latest/', None),
+                       'emodpy-calibra': ('https://docs.idmod.org/projects/emodpy-calibra/en/latest/', None),
+                       'emodpy-malaria': ('https://docs.idmod.org/projects/emodpy-malaria/en/latest/', None),
+                       'emodpy-measles': ('https://docs.idmod.org/projects/emodpy-measles/en/latest/', None),
+                       'emodpy-tbhiv': ('https://docs.idmod.org/projects/emodpy-tbhiv/en/latest/', None),
+                       'emodpy-covid': ('https://docs.idmod.org/projects/emodpy-covid/en/latest/', None),
+                       'emodpy-generic': ('https://docs.idmod.org/projects/emodpy-generic/en/latest/', None),
+                       'emodpy-hiv': ('https://docs.idmod.org/projects/emodpy-hiv/en/latest/', None),
+                       'emod-generic': ('https://docs.idmod.org/projects/emod-generic/en/latest/', None),
+                       'emod-malaria': ('https://docs.idmod.org/projects/emod-malaria/en/latest/', None),
+                       'emod-vector': ('https://docs.idmod.org/projects/emod-vector/en/latest/', None),
+                       'emod-hiv': ('https://docs.idmod.org/projects/emod-hiv/en/latest/', None),
+                       'emod-sti': ('https://docs.idmod.org/projects/emod-sti/en/latest/', None),
+                       'emod-airborne': ('https://docs.idmod.org/projects/emod-airborne/en/latest/', None),
+                       'emod-tbhiv': ('https://docs.idmod.org/projects/emod-tuberculosis/en/latest/', None),
+                       'emod-environmental': ('https://docs.idmod.org/projects/emod-environmental/en/latest/', None),
+                       'emod-typhoid': ('https://docs.idmod.org/projects/emod-typhoid/en/latest/', None),
+                       'vis-tools': ('https://docs.idmod.org/projects/vis-tools/en/latest/', None),
+                       'pycomps': ('https://docs.idmod.org/projects/pycomps/en/latest/', None),
+                       'covasim': ('https://docs.idmod.org/projects/covasim/en/latest/', None),
+                       'synthpops': ('https://docs.idmod.org/projects/synthpops/en/latest/', None),
+                       'dymodetron': ('https://docs.idmod.org/projects/dymodetron/en/latest/', None),
+                       'cms': ('https://docs.idmod.org/projects/cms/en/latest/', None)
+                       }

--- a/{{ cookiecutter.library_name }}/docs/conf.py
+++ b/{{ cookiecutter.library_name }}/docs/conf.py
@@ -50,7 +50,8 @@ extensions = [
     'plantweb.directive',
     'sphinxcontrib.programoutput',
     'sphinx.ext.intersphinx',
-    'sphinxext.remoteliteralinclude'
+    'sphinxext.remoteliteralinclude',
+    'sphinx_copybutton'
 ]
 
 plantuml = 'plantweb'
@@ -199,9 +200,12 @@ html_static_path = ['_static']
 
 html_context = {
     'css_files': [
-        '_static/theme_overrides.css'
+        '_static/theme_overrides.css',
+        '_static/copy_button.css'
     ]
 }
+
+html_js_files = ['show_block_by_os.js']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the docs.

--- a/{{ cookiecutter.library_name }}/docs/index.rst
+++ b/{{ cookiecutter.library_name }}/docs/index.rst
@@ -1,8 +1,9 @@
-====================
+=================================================
 Welcome to |{{ cookiecutter.sphinx_short_name }}|
-====================
+=================================================
 
-|{{ cookiecutter.sphinx_short_name }}| give short description on purpose of library.
+|{{ cookiecutter.sphinx_short_name }}| give short description on purpose of library,
+which can be found on Github_.
 
 .. _GitHub: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repo_name }}
 

--- a/{{ cookiecutter.library_name }}/docs/installation.rst
+++ b/{{ cookiecutter.library_name }}/docs/installation.rst
@@ -18,7 +18,3 @@ more information, see documentation for venv_ or Anaconda_.
 Installation
 ============
 
-
-
-Quick start guide
-=================

--- a/{{ cookiecutter.library_name }}/docs/make.bat
+++ b/{{ cookiecutter.library_name }}/docs/make.bat
@@ -5,7 +5,7 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SPHINXOPTS=-W
+set SPHINXOPTS=-W -t {{ cookiecutter.library_name.replace("_", "-") }}
 set BUILDDIR=_build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
 set I18NSPHINXOPTS=%SPHINXOPTS% .

--- a/{{ cookiecutter.library_name }}/docs/overview.rst
+++ b/{{ cookiecutter.library_name }}/docs/overview.rst
@@ -1,5 +1,5 @@
-================
+===============================================
 |{{ cookiecutter.sphinx_short_name }}| overview
-================
+===============================================
 
-Add overview of library here
+Add conceptual overview of library here.

--- a/{{ cookiecutter.library_name }}/docs/requirements.txt
+++ b/{{ cookiecutter.library_name }}/docs/requirements.txt
@@ -1,5 +1,9 @@
+plantweb~=1.2.1
+pygit2~=1.4.0
+PyGithub~=1.54
+sphinx-copybutton~=0.3.1
 sphinx-rtd-theme~=0.5.0
 sphinxcontrib-napoleon~=0.7
-sphinx~=3.3.1
-plantweb~=1.2.1
 sphinxcontrib-programoutput~=0.16
+sphinx~=3.3.1
+sphinxext.remoteliteralinclude

--- a/{{ cookiecutter.library_name }}/docs/requirements.txt
+++ b/{{ cookiecutter.library_name }}/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinxcontrib-napoleon~=0.7
 sphinxcontrib-programoutput~=0.16
 sphinx~=3.3.1
 sphinxext.remoteliteralinclude
+sphinx-copybutton~=0.4.0

--- a/{{ cookiecutter.library_name }}/docs/variables.txt
+++ b/{{ cookiecutter.library_name }}/docs/variables.txt
@@ -17,5 +17,22 @@
 .. |IDM_s| replace:: IDM
 .. |{{ cookiecutter.sphinx_short_name }}| replace:: {{ cookiecutter.project_name }}
 .. |Python_supp| replace:: Python 3.6 64-bit
+.. |EMODPY_s| replace:: emodpy
+.. |EMODPY_malaria| replace:: emodpy-malaria
+.. |EMODPY_generic| replace:: emodpy-generic
+.. |EMODPY_hiv| replace:: emodpy-hiv
+.. |EMODPY_tbhiv| replace:: emodpy-tbhiv
+.. |emod_api| replace:: emod-api
+.. |EMOD_l| replace:: Epidemiological MODeling software (EMOD)
+.. |EMOD_s| replace:: EMOD
+.. |IT_l| replace:: idmtools
+.. |IT_s| replace:: idmtools
+.. |SSMT_l| replace:: Server-Side Modeling Tools (SSMT)
+.. |SSMT_s| replace:: SSMT
+.. |COMPS_l| replace:: COmputational Modeling Platform Service (COMPS)
+.. |COMPS_s| replace:: COMPS
+.. |exe_l| replace:: EMOD executable (Eradication.exe)
+.. |exe_s| replace:: Eradication.exe
+.. |linux_binary| replace:: Eradication binary for Linux
 
-.. _GitHub repository: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repo_name }}
+.. _GitHub: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repo_name }}


### PR DESCRIPTION
I added some new Sphinx functionality to the config, including intersphinx mapping. I also recently found an issue with the "Edit on GitHub" links with the way we were overwriting the breadcrumbs.html file, so this is now fixed. Also added a few more variables for additional projects/terms. 

Can you verify that the cookiecutter replace syntax will work in make.bat and makefile?  The `-t tag` syntax in SPHINXOPTS is what enables conditonalization of text using the `only` directive for local builds. There were a couple things I missed in Makefile for my earlier PR (the external build, which we don't use anymore). 