### PR TITLE
updated rtd.yml to new required keys

### DIFF
--- a/{{ cookiecutter.library_name }}/.readthedocs.yml
+++ b/{{ cookiecutter.library_name }}/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -21,7 +26,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
       - requirements: dev_scripts/package_requirements.txt
       - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the Docs is deprecating the build.image config and requiring the build.os and build.tools config of readthedocs.yml. This adds the new required config. 